### PR TITLE
cleanup for tsx files

### DIFF
--- a/src/endpoint/simple-fastapi-container/src/playground/src/components/ImageCard.tsx
+++ b/src/endpoint/simple-fastapi-container/src/playground/src/components/ImageCard.tsx
@@ -1,13 +1,6 @@
 import {
   Body1,
   Button,
-  Dialog,
-  DialogActions,
-  DialogBody,
-  DialogContent,
-  DialogSurface,
-  DialogTitle,
-  DialogTrigger,
   Input,
   Label,
   Spinner,

--- a/src/endpoint/simple-fastapi-container/src/playground/src/pages/Image.tsx
+++ b/src/endpoint/simple-fastapi-container/src/playground/src/pages/Image.tsx
@@ -1,6 +1,6 @@
 import { makeStyles } from "@fluentui/react-components";
 import { ImageParamsCard } from "../components/ImageParamsCard";
-import { ImageGenerationOptions, ImageGenerations } from "@azure/openai";
+import { ImageGenerationOptions } from "@azure/openai";
 import { useState } from "react";
 import { useEventDataContext } from "../providers/EventDataProvider";
 import { ImageCard, ImageDetails } from "../components/ImageCard";
@@ -44,7 +44,7 @@ export const Image = () => {
       return;
     }
 
-    const id = Date.now()
+    const id = Date.now();
 
     setImages((current) => [...current, { prompt, loaded: false, id }]);
 


### PR DESCRIPTION
This pull request includes changes to improve the codebase of the `simple-fastapi-container` project. The most important changes include removing code for certain components from `ImageCard.tsx` and making modifications to the import statement and variable assignment in `Image.tsx`.

Main code changes:

* <a href="diffhunk://#diff-86235b84862dc20f6da444427e4a180c281ae4af997eb7f86743e179369c35d3L4-L10">`src/endpoint/simple-fastapi-container/src/playground/src/components/ImageCard.tsx`</a>: Removed code for the `Dialog`, `DialogActions`, `DialogBody`, `DialogContent`, `DialogSurface`, and `DialogTitle` components.
* <a href="diffhunk://#diff-78a8eddb62602b4472ecf5ba55cfe32f1bae69635d55fbae89a8502ba7e6a657L3-R3">`src/endpoint/simple-fastapi-container/src/playground/src/pages/Image.tsx`</a>: Removed the import statement for `ImageGenerations` from the `@azure/openai` library and added a semicolon after the assignment of `Date.now()` to the `id` variable. <a href="diffhunk://#diff-78a8eddb62602b4472ecf5ba55cfe32f1bae69635d55fbae89a8502ba7e6a657L3-R3">[1]</a> <a href="diffhunk://#diff-78a8eddb62602b4472ecf5ba55cfe32f1bae69635d55fbae89a8502ba7e6a657L47-R47">[2]</a>