### PR TITLE
Move event code to header and store in local storage

### DIFF
--- a/src/endpoint/simple-fastapi-container/src/playground/src/components/ChatParamsCard.tsx
+++ b/src/endpoint/simple-fastapi-container/src/playground/src/components/ChatParamsCard.tsx
@@ -4,7 +4,6 @@ import { useCallback } from "react";
 import { UsageData } from "../interfaces/UsageData";
 import { useEventDataContext } from "../providers/EventDataProvider";
 import { DividerBlock } from "./DividerBlock";
-import { EventCodeInput } from "./EventCodeInput";
 import type { GetChatCompletionsOptions } from "@azure/openai";
 import { Card } from "./Card";
 
@@ -35,8 +34,6 @@ export const ChatParamsCard = ({
 
   return (
     <Card header="Configuration">
-      <EventCodeInput />
-
       <DividerBlock>
         <ParamInput
           label="Tokens"

--- a/src/endpoint/simple-fastapi-container/src/playground/src/components/EventCodeInput.tsx
+++ b/src/endpoint/simple-fastapi-container/src/playground/src/components/EventCodeInput.tsx
@@ -1,51 +1,57 @@
-import { Button, Input, Label, makeStyles } from "@fluentui/react-components";
+import {
+  Button,
+  Input,
+  Label,
+  makeStyles,
+  shorthands,
+  useId,
+} from "@fluentui/react-components";
 import { useState } from "react";
 import { useEventDataContext } from "../providers/EventDataProvider";
-import { DividerBlock } from "./DividerBlock";
 
 const useStyles = makeStyles({
-  smallbutton: {
-    width: "100%",
-    height: "50%",
-    maxWidth: "none",
-    maxHeight: "25%",
-    backgroundColor: "#f2f2f2",
+  container: {
+    display: "flex",
+    flexDirection: "row",
+    columnGap: "5px",
+    alignItems: "center",
+    ...shorthands.padding("10px", 0, 0, 0),
   },
 });
 
-export const EventCodeInput = () => {
+export const ApiKeyInput = () => {
+  const [code, setCode] = useState("");
+  const { eventData, isAuthorized, setEventCode } = useEventDataContext();
+  const inputId = useId();
   const styles = useStyles();
-  const { eventData, isAuthorized, setEventCode, eventCode } =
-    useEventDataContext();
-  const [code, setCode] = useState(eventCode || "");
 
   return (
-    <DividerBlock>
-      <Label
-        style={{
-          fontSize: "medium",
-          marginBottom: "0.5rem",
-          textAlign: "justify",
-        }}
-      >
-        <b>Event Code</b>
-      </Label>
-      <Input
-        type="password"
-        placeholder="Enter your Event Code"
-        value={code}
-        onChange={(e) => setCode(e.target.value)}
-        style={{ textAlign: "right" }}
-      />
-
+    <div className={styles.container}>
       {!isAuthorized && (
         <>
+          <Label htmlFor={inputId}>API Key</Label>
+          <Input
+            type="password"
+            placeholder="Enter your API Key"
+            value={code}
+            onChange={(e) => setCode(e.target.value)}
+            id={inputId}
+          />
+
           <Button
-            className={styles.smallbutton}
-            onClick={() => setEventCode(code)}
+            onClick={(e) => {
+              e.preventDefault();
+              return setEventCode(code);
+            }}
+            appearance="primary"
+            disabled={code.length === 0}
           >
-            Log In
+            Authorize
           </Button>
+        </>
+      )}
+      {isAuthorized && (
+        <>
           <Label
             style={{
               color: "GrayText",
@@ -53,26 +59,29 @@ export const EventCodeInput = () => {
               textAlign: "justify",
             }}
           >
-            Provided by workshop host.
+            <div>{eventData!.name}</div>
+            <div>
+              <a
+                href={eventData!.url}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {eventData!.url_text}
+              </a>
+            </div>
           </Label>
+          <Button
+            onClick={(e) => {
+              e.preventDefault();
+              setCode("");
+              return setEventCode("");
+            }}
+            appearance="primary"
+          >
+            Logout
+          </Button>
         </>
       )}
-      {isAuthorized && (
-        <Label
-          style={{
-            color: "GrayText",
-            fontSize: "small",
-            textAlign: "justify",
-          }}
-        >
-          <div>{eventData!.name}</div>
-          <div>
-            <a href={eventData!.url} target="_blank" rel="noopener noreferrer">
-              {eventData!.url_text}
-            </a>
-          </div>
-        </Label>
-      )}
-    </DividerBlock>
+    </div>
   );
 };

--- a/src/endpoint/simple-fastapi-container/src/playground/src/components/Headers.tsx
+++ b/src/endpoint/simple-fastapi-container/src/playground/src/components/Headers.tsx
@@ -1,19 +1,44 @@
-import { Tab, TabList } from "@fluentui/react-components";
+import {
+  Tab,
+  TabList,
+  makeStyles,
+  shorthands,
+} from "@fluentui/react-components";
 import { useLocation, useNavigate } from "react-router-dom";
+import { ApiKeyInput } from "./EventCodeInput";
+
+const useStyles = makeStyles({
+  container: {
+    display: "grid",
+    gridTemplateColumns: "2fr 1fr",
+  },
+  right: {
+    justifySelf: "right",
+    ...shorthands.padding("0px", "20px", "0px", "0px"),
+  },
+});
 
 export const Header = () => {
   const location = useLocation();
   const navigate = useNavigate();
+  const styles = useStyles();
 
   return (
-    <TabList
-      selectedValue={location.pathname === "/" ? "chat" : "images"}
-      onTabSelect={(_, data) => {
-        data.value === "chat" ? navigate("/") : navigate(`/${data.value}`);
-      }}
-    >
-      <Tab value="chat">Chat</Tab>
-      <Tab value="images">Image</Tab>
-    </TabList>
+    <>
+      <div className={styles.container}>
+        <TabList
+          selectedValue={location.pathname === "/" ? "chat" : "images"}
+          onTabSelect={(_, data) => {
+            data.value === "chat" ? navigate("/") : navigate(`/${data.value}`);
+          }}
+        >
+          <Tab value="chat">Chat</Tab>
+          <Tab value="images">Image</Tab>
+        </TabList>
+        <div className={styles.right}>
+          <ApiKeyInput />
+        </div>
+      </div>
+    </>
   );
 };

--- a/src/endpoint/simple-fastapi-container/src/playground/src/components/ImageParamsCard.tsx
+++ b/src/endpoint/simple-fastapi-container/src/playground/src/components/ImageParamsCard.tsx
@@ -1,6 +1,5 @@
 import { Label, Select, useId } from "@fluentui/react-components";
 import { Card } from "./Card";
-import { EventCodeInput } from "./EventCodeInput";
 import { DividerBlock } from "./DividerBlock";
 import { ParamInput } from "./ParamInput";
 import { ImageGenerationOptions } from "@azure/openai";
@@ -23,8 +22,6 @@ export const ImageParamsCard = ({
   const { isAuthorized } = useEventDataContext();
   return (
     <Card header="Configuration">
-      <EventCodeInput />
-
       <DividerBlock>
         <ParamInput
           label="Number of images"

--- a/src/endpoint/simple-fastapi-container/src/playground/src/providers/EventDataProvider.tsx
+++ b/src/endpoint/simple-fastapi-container/src/playground/src/providers/EventDataProvider.tsx
@@ -39,11 +39,16 @@ export const EventDataContext = createContext<EventDataContextValue>({
   authStatus: AuthStatus.NotSet,
 });
 
+const EVENT_CODE_STORAGE_KEY = "aoai:playground:eventCode";
+const storage = localStorage;
+
 const EventDataProvider: React.FC<PropsWithChildren> = ({ children }) => {
   const [eventData, setEventData] = useState<EventData | undefined>(undefined);
   const [authStatus, setAuthStatus] = useState<AuthStatus>(AuthStatus.NotSet);
 
-  const [eventCode, setEventCode] = useState<string>("");
+  const [eventCode, setEventCode] = useState<string>(
+    storage.getItem(EVENT_CODE_STORAGE_KEY) || ""
+  );
 
   useEffect(() => {
     const getEventData = async (eventCode: string) => {
@@ -57,6 +62,7 @@ const EventDataProvider: React.FC<PropsWithChildren> = ({ children }) => {
         }));
         if (data.is_authorized) {
           setAuthStatus(AuthStatus.Authorized);
+          storage.setItem(EVENT_CODE_STORAGE_KEY, eventCode);
         } else {
           setAuthStatus(AuthStatus.NotAuthorized);
         }
@@ -66,6 +72,7 @@ const EventDataProvider: React.FC<PropsWithChildren> = ({ children }) => {
     };
 
     if (!eventCode) {
+      storage.removeItem(EVENT_CODE_STORAGE_KEY);
       setAuthStatus(AuthStatus.NotSet);
       return;
     }

--- a/src/endpoint/simple-fastapi-container/src/playground/vite.config.ts
+++ b/src/endpoint/simple-fastapi-container/src/playground/vite.config.ts
@@ -6,6 +6,9 @@ export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), "");
   return {
     plugins: [react()],
+    define: {
+      'process.env.NODE_ENV': JSON.stringify(mode),
+    },
     server: {
       proxy: {
         "/v1": env.API_URL,


### PR DESCRIPTION
This pull request includes the following changes:

- Moving event code to the header of the page

- Storing event code in local storage for persistence across reloads

These changes improve the user experience by making the event code easily accessible in the header and ensuring that it is retained even after reloading the page.

Fixes #29, fixes #30

![Example of the new UI](https://github.com/gloveboxes/azure-openai-service-proxy/assets/434140/0090e035-b01e-4c08-8b98-9b742012796d)
